### PR TITLE
Allow multiple handlers in a group for a trigger

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -9,14 +9,14 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x]
+        node: ["12", "14", "16"]
 
     steps:
-    - uses: actions/checkout@v1
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node }}
+      uses: actions/setup-node@v2
       with:
-        node-version: ${{ matrix.node-version }}
+        node-version: ${{ matrix.node }}
     - name: npm install, run build/lint/tsc
       run: |
         npm install

--- a/src/focused-stack/index.ts
+++ b/src/focused-stack/index.ts
@@ -115,8 +115,8 @@ class FocusedKeyHandlerStack {
     const handlerKey = this.getKey(trigger);
     this.stack = this.stack.map((group: HandlerGroup) => {
       if (group.groupId === groupId) {
-        // eslint-disable-next-line no-param-reassign
         const handlersAtKey = group.handlers[handlerKey] || [];
+        // eslint-disable-next-line no-param-reassign
         group.handlers = {
           ...group.handlers,
           [handlerKey]: handlersAtKey.filter(

--- a/src/focused-stack/spec.ts
+++ b/src/focused-stack/spec.ts
@@ -10,6 +10,7 @@ describe("Focused Hanlder Stack", () => {
   });
   it("fires correct event", () => {
     const mockHandler = jest.fn();
+    const anotherHandler = jest.fn();
     const unusedHandler = jest.fn();
     const id1 = FocusedKeyHandlerStack.getGroupId();
     const id2 = FocusedKeyHandlerStack.getGroupId();
@@ -19,10 +20,12 @@ describe("Focused Hanlder Stack", () => {
 
     FocusedKeyHandlerStack.pushGroup(id2);
     FocusedKeyHandlerStack.pushHandler(id2, mockHandler, { key: "Escape" });
+    FocusedKeyHandlerStack.pushHandler(id2, anotherHandler, { key: "Escape" });
 
     FocusedKeyHandlerStack.fireEvent({ code: "Escape" } as any);
 
     expect(mockHandler).toHaveBeenCalled();
+    expect(anotherHandler).toHaveBeenCalled();
     expect(unusedHandler).not.toHaveBeenCalled();
   });
 
@@ -132,6 +135,31 @@ describe("Focused Hanlder Stack", () => {
 
     FocusedKeyHandlerStack.fireEvent({ code: "Escape" } as any);
 
+    expect(unusedHandler).not.toHaveBeenCalled();
+  });
+  it("removes only the removed event from the group", () => {
+    const mockHandler = jest.fn();
+    const anotherHandler = jest.fn();
+    const unusedHandler = jest.fn();
+    const id1 = FocusedKeyHandlerStack.getGroupId();
+    const id2 = FocusedKeyHandlerStack.getGroupId();
+
+    FocusedKeyHandlerStack.pushGroup(id1);
+    FocusedKeyHandlerStack.pushHandler(id1, unusedHandler, { key: "Escape" });
+
+    FocusedKeyHandlerStack.pushGroup(id2);
+    FocusedKeyHandlerStack.pushHandler(id2, mockHandler, { key: "Escape" });
+    FocusedKeyHandlerStack.pushHandler(id2, anotherHandler, { key: "Escape" });
+    FocusedKeyHandlerStack.removeAtIdAndTrigger(
+      id2,
+      { key: "Escape" },
+      anotherHandler
+    );
+
+    FocusedKeyHandlerStack.fireEvent({ code: "Escape" } as any);
+
+    expect(mockHandler).toHaveBeenCalled();
+    expect(anotherHandler).not.toHaveBeenCalled();
     expect(unusedHandler).not.toHaveBeenCalled();
   });
 });

--- a/src/key-handler/body.tsx
+++ b/src/key-handler/body.tsx
@@ -66,7 +66,11 @@ export default class KeyHandler extends React.Component<OwnProps> {
     const { focusGroupId } = this.context;
     if (focusGroupId !== undefined) {
       this.props.triggers.forEach((trigger: Trigger) =>
-        FocusedHandlerStack.removeAtIdAndTrigger(focusGroupId, trigger)
+        FocusedHandlerStack.removeAtIdAndTrigger(
+          focusGroupId,
+          trigger,
+          this.handleKey
+        )
       );
     } else {
       document.body.removeEventListener(this.eventType, this.handleKey);

--- a/src/spec.tsx
+++ b/src/spec.tsx
@@ -1,0 +1,46 @@
+import * as React from "react";
+import { render, cleanup, fireEvent } from "@testing-library/react";
+
+import KeyHandler, { Provider, FocusGroup } from "./index";
+
+describe("<KeyHandler />", () => {
+  afterEach(cleanup);
+
+  test("no group: matching key is triggered on the body", () => {
+    const handlerSpy = jest.fn();
+    render(<KeyHandler triggers={[{ key: "KeyA" }]} handler={handlerSpy} />);
+
+    fireEvent.keyDown(document.body, { code: "KeyA" });
+    expect(handlerSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("with group: matching key is triggered", () => {
+    const handlerSpy = jest.fn();
+    const anotherSpy = jest.fn();
+    const unusedHandlerSpy = jest.fn();
+    render(
+      <div>
+        <Provider />
+        <div>
+          <FocusGroup>
+            <KeyHandler
+              triggers={[{ key: "KeyA" }]}
+              handler={unusedHandlerSpy}
+            />
+            <div>
+              <FocusGroup>
+                <KeyHandler triggers={[{ key: "KeyA" }]} handler={handlerSpy} />
+                <KeyHandler triggers={[{ key: "KeyA" }]} handler={anotherSpy} />
+              </FocusGroup>
+            </div>
+          </FocusGroup>
+        </div>
+      </div>
+    );
+
+    fireEvent.keyDown(document.body, { code: "KeyA" });
+    expect(handlerSpy).toHaveBeenCalledTimes(1);
+    expect(anotherSpy).toHaveBeenCalledTimes(1);
+    expect(unusedHandlerSpy).toHaveBeenCalledTimes(0);
+  });
+});


### PR DESCRIPTION
This should probably be considered a breaking change, but we're pre-1.0 here. Interested in hearing opinions about breakage for this public package.

We were only allowing a single handler per "trigger", so if two separate components in the same group wanted to hook into the same trigger, the last one to mount was the only one that would be fired.

Removing the handlers got a bit more difficult since we needed some way of identifying the function to remove in the array of functions, but luckily object reference identity of the handler functions themselves seems to work according to the tests. 🎉 