### PR TITLE
Update key/group registration order to parent -> child

### DIFF
--- a/src/focus-group/index.tsx
+++ b/src/focus-group/index.tsx
@@ -3,6 +3,7 @@ import React, {
   useContext,
   useLayoutEffect,
   useMemo,
+  useState,
   ReactNode,
 } from "react";
 import { useFocusedStack } from "../focused-stack/context";
@@ -22,12 +23,14 @@ interface OwnProps {
 export function FocusGroup(props: OwnProps) {
   const focusedStack = useFocusedStack();
   const focusGroupId = useMemo(() => focusedStack.getGroupId(), [focusedStack]);
+  const [groupPushed, setGroupPushed] = useState<boolean>(false);
 
   // Layout effect fires before rendering children to ensure that groups are
   // pushed before handlers are added
   useLayoutEffect(
     function groupLifecycle() {
       focusedStack.pushGroup(focusGroupId);
+      setGroupPushed(true);
 
       return () => {
         focusedStack.removeGroup(focusGroupId);
@@ -38,7 +41,7 @@ export function FocusGroup(props: OwnProps) {
 
   return (
     <FocusContext.Provider value={{ focusGroupId }}>
-      {props.children}
+      {groupPushed && props.children}
     </FocusContext.Provider>
   );
 }

--- a/src/focus-group/index.tsx
+++ b/src/focus-group/index.tsx
@@ -34,6 +34,7 @@ export function FocusGroup(props: OwnProps) {
 
       return () => {
         focusedStack.removeGroup(focusGroupId);
+        setGroupPushed(false);
       };
     },
     [focusGroupId, focusedStack]

--- a/src/focused-stack/index.ts
+++ b/src/focused-stack/index.ts
@@ -52,7 +52,25 @@ export class FocusedStack {
     }
     const key = this.getKeyCodeFromEvent(e);
 
-    const handlerGroup = this.stack[this.stack.length - 1];
+    const handlerGroup = this.stack.reduce(
+      (acc: HandlerGroup | null, group: HandlerGroup): HandlerGroup | null => {
+        if (acc === null) {
+          return group;
+        }
+
+        if (group.groupId > acc.groupId) {
+          return group;
+        }
+
+        return acc;
+      },
+      null
+    );
+
+    if (!handlerGroup) {
+      return;
+    }
+
     const handlerObjects = handlerGroup.handlers[key];
 
     if (!handlerObjects) {
@@ -77,6 +95,14 @@ export class FocusedStack {
   };
 
   public pushGroup = (groupId: number): void => {
+    const exists = this.stack.find(
+      (group: HandlerGroup) => group.groupId === groupId
+    );
+
+    if (exists) {
+      return;
+    }
+
     this.stack.push({
       groupId,
       handlers: {},

--- a/src/focused-stack/index.ts
+++ b/src/focused-stack/index.ts
@@ -52,7 +52,7 @@ export class FocusedStack {
     }
     const key = this.getKeyCodeFromEvent(e);
 
-    const handlerGroup = this.stack[0];
+    const handlerGroup = this.stack[this.stack.length - 1];
     const handlerObjects = handlerGroup.handlers[key];
 
     if (!handlerObjects) {

--- a/src/focused-stack/spec.ts
+++ b/src/focused-stack/spec.ts
@@ -21,13 +21,12 @@ describe("Focused Hanlder Stack", () => {
     const id1 = FocusedKeyHandlerStack.getGroupId();
     const id2 = FocusedKeyHandlerStack.getGroupId();
 
-    // useEffect fires "bottom-up", so deeper groups are added first
+    FocusedKeyHandlerStack.pushGroup(id1);
+    FocusedKeyHandlerStack.pushHandler(id1, unusedHandler, { key: "Escape" });
+
     FocusedKeyHandlerStack.pushGroup(id2);
     FocusedKeyHandlerStack.pushHandler(id2, mockHandler, { key: "Escape" });
     FocusedKeyHandlerStack.pushHandler(id2, anotherHandler, { key: "Escape" });
-
-    FocusedKeyHandlerStack.pushGroup(id1);
-    FocusedKeyHandlerStack.pushHandler(id1, unusedHandler, { key: "Escape" });
 
     FocusedKeyHandlerStack.fireEvent({ code: "Escape" } as any);
 
@@ -66,12 +65,11 @@ describe("Focused Hanlder Stack", () => {
     const id1 = FocusedKeyHandlerStack.getGroupId();
     const id2 = FocusedKeyHandlerStack.getGroupId();
 
-    FocusedKeyHandlerStack.pushGroup(id2);
-    FocusedKeyHandlerStack.pushHandler(id2, group2Handler, { key: "Escape" });
-
     FocusedKeyHandlerStack.pushGroup(id1);
     FocusedKeyHandlerStack.pushHandler(id1, group1Handler, { key: "Escape" });
 
+    FocusedKeyHandlerStack.pushGroup(id2);
+    FocusedKeyHandlerStack.pushHandler(id2, group2Handler, { key: "Escape" });
     FocusedKeyHandlerStack.removeGroup(id2);
 
     FocusedKeyHandlerStack.fireEvent({ code: "Escape" } as any);
@@ -84,11 +82,10 @@ describe("Focused Hanlder Stack", () => {
     const id1 = FocusedKeyHandlerStack.getGroupId();
     const id2 = FocusedKeyHandlerStack.getGroupId();
 
-    FocusedKeyHandlerStack.pushGroup(id2);
-    FocusedKeyHandlerStack.pushHandler(id2, group2Handler, { key: "Escape" });
-
     FocusedKeyHandlerStack.pushGroup(id1);
 
+    FocusedKeyHandlerStack.pushGroup(id2);
+    FocusedKeyHandlerStack.pushHandler(id2, group2Handler, { key: "Escape" });
     FocusedKeyHandlerStack.removeGroup(id2);
 
     FocusedKeyHandlerStack.fireEvent({ code: "Escape" } as any);
@@ -135,10 +132,10 @@ describe("Focused Hanlder Stack", () => {
     const id1 = FocusedKeyHandlerStack.getGroupId();
     const id2 = FocusedKeyHandlerStack.getGroupId();
 
-    FocusedKeyHandlerStack.pushGroup(id2);
-
     FocusedKeyHandlerStack.pushGroup(id1);
     FocusedKeyHandlerStack.pushHandler(id1, unusedHandler, { key: "Escape" });
+
+    FocusedKeyHandlerStack.pushGroup(id2);
 
     FocusedKeyHandlerStack.fireEvent({ code: "Escape" } as any);
 
@@ -151,12 +148,12 @@ describe("Focused Hanlder Stack", () => {
     const id1 = FocusedKeyHandlerStack.getGroupId();
     const id2 = FocusedKeyHandlerStack.getGroupId();
 
+    FocusedKeyHandlerStack.pushGroup(id1);
+    FocusedKeyHandlerStack.pushHandler(id1, unusedHandler, { key: "Escape" });
+
     FocusedKeyHandlerStack.pushGroup(id2);
     FocusedKeyHandlerStack.pushHandler(id2, mockHandler, { key: "Escape" });
     FocusedKeyHandlerStack.pushHandler(id2, anotherHandler, { key: "Escape" });
-
-    FocusedKeyHandlerStack.pushGroup(id1);
-    FocusedKeyHandlerStack.pushHandler(id1, unusedHandler, { key: "Escape" });
 
     FocusedKeyHandlerStack.removeAtIdAndTrigger(
       id2,

--- a/src/key-handler/index.tsx
+++ b/src/key-handler/index.tsx
@@ -48,7 +48,9 @@ export function KeyHandler(props: KeyHandlerProps) {
   useLayoutEffect(
     function handlerLifecycle() {
       if (focusGroupId === null) {
-        return;
+        return () => {
+          /* consistent return type */
+        };
       }
 
       triggers.forEach((trigger: Trigger) =>

--- a/src/key-handler/index.tsx
+++ b/src/key-handler/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useLayoutEffect } from "react";
 
 import { useFocusGroupId } from "../focus-group";
 import { useFocusedStack } from "../focused-stack/context";
@@ -45,24 +45,20 @@ export function KeyHandler(props: KeyHandlerProps) {
   const focusGroupId = useFocusGroupId();
   const focusedStack = useFocusedStack();
 
-  useEffect(
+  useLayoutEffect(
     function handlerLifecycle() {
-      if (focusGroupId !== null) {
-        triggers.forEach((trigger: Trigger) =>
-          focusedStack.pushHandler(focusGroupId, handleKey, trigger)
-        );
-      } else {
-        document.body.addEventListener("keydown", handleKey);
+      if (focusGroupId === null) {
+        return;
       }
 
+      triggers.forEach((trigger: Trigger) =>
+        focusedStack.pushHandler(focusGroupId, handleKey, trigger)
+      );
+
       return () => {
-        if (focusGroupId !== null) {
-          triggers.forEach((trigger: Trigger) =>
-            focusedStack.removeAtIdAndTrigger(focusGroupId, trigger, handleKey)
-          );
-        } else {
-          document.body.removeEventListener("keydown", handleKey);
-        }
+        triggers.forEach((trigger: Trigger) =>
+          focusedStack.removeAtIdAndTrigger(focusGroupId, trigger, handleKey)
+        );
       };
     },
     [focusedStack, focusGroupId, handler, triggers, handleKey]

--- a/src/spec.tsx
+++ b/src/spec.tsx
@@ -12,61 +12,56 @@ function TestComponent() {
   });
   return (
     <div>
-      <Provider>
-        <div>
+      <div>
+        <span>Parent: {clickCounts.parent}</span>
+        <span>Child: {clickCounts.child}</span>
+        <span>Sibling: {clickCounts.sibling}</span>
+        <span>Unused: {clickCounts.unused}</span>
+      </div>
+      <FocusGroup>
+        <KeyHandler
+          triggers={[{ key: "KeyA" }]}
+          handler={() =>
+            setClickCounts((prev) => ({
+              ...prev,
+              parent: prev.parent + 1,
+            }))
+          }
+        />
+        {clickCounts.parent > 0 && clickCounts.child === 0 && (
           <div>
-            <span>Parent: {clickCounts.parent}</span>
-            <span>Child: {clickCounts.child}</span>
-            <span>Sibling: {clickCounts.sibling}</span>
-            <span>Unused: {clickCounts.unused}</span>
+            <FocusGroup>
+              <KeyHandler
+                triggers={[{ key: "KeyA" }]}
+                handler={() =>
+                  setClickCounts((prev) => ({
+                    ...prev,
+                    child: prev.child + 1,
+                  }))
+                }
+              />
+              <KeyHandler
+                triggers={[{ key: "KeyA" }]}
+                handler={() =>
+                  setClickCounts((prev) => ({
+                    ...prev,
+                    sibling: prev.sibling + 1,
+                  }))
+                }
+              />
+              <KeyHandler
+                triggers={[{ key: "KeyV" }]}
+                handler={() =>
+                  setClickCounts((prev) => ({
+                    ...prev,
+                    unused: prev.unused + 1,
+                  }))
+                }
+              />
+            </FocusGroup>
           </div>
-          <FocusGroup>
-            <KeyHandler
-              triggers={[{ key: "KeyA" }]}
-              handler={() =>
-                setClickCounts((prev) => ({
-                  ...prev,
-                  parent: prev.parent + 1,
-                }))
-              }
-            />
-            {clickCounts.parent > 0 && (
-              <div>
-                <span>Showing!</span>
-                <FocusGroup>
-                  <KeyHandler
-                    triggers={[{ key: "KeyA" }]}
-                    handler={() =>
-                      setClickCounts((prev) => ({
-                        ...prev,
-                        child: prev.child + 1,
-                      }))
-                    }
-                  />
-                  <KeyHandler
-                    triggers={[{ key: "KeyA" }]}
-                    handler={() =>
-                      setClickCounts((prev) => ({
-                        ...prev,
-                        sibling: prev.sibling + 1,
-                      }))
-                    }
-                  />
-                  <KeyHandler
-                    triggers={[{ key: "KeyV" }]}
-                    handler={() =>
-                      setClickCounts((prev) => ({
-                        ...prev,
-                        unused: prev.unused + 1,
-                      }))
-                    }
-                  />
-                </FocusGroup>
-              </div>
-            )}
-          </FocusGroup>
-        </div>
-      </Provider>
+        )}
+      </FocusGroup>
     </div>
   );
 }
@@ -75,7 +70,11 @@ describe("<KeyHandler />", () => {
   afterEach(cleanup);
 
   test("matching key is triggered", () => {
-    const component = render(<TestComponent />);
+    const component = render(
+      <Provider>
+        <TestComponent />
+      </Provider>
+    );
 
     fireEvent.keyDown(document.body, { code: "KeyA" });
     expect(component.queryByText("Parent: 1")).toBeTruthy();
@@ -85,6 +84,12 @@ describe("<KeyHandler />", () => {
 
     fireEvent.keyDown(document.body, { code: "KeyA" });
     expect(component.queryByText("Parent: 1")).toBeTruthy();
+    expect(component.queryByText("Child: 1")).toBeTruthy();
+    expect(component.queryByText("Sibling: 1")).toBeTruthy();
+    expect(component.queryByText("Unused: 0")).toBeTruthy();
+
+    fireEvent.keyDown(document.body, { code: "KeyA" });
+    expect(component.queryByText("Parent: 2")).toBeTruthy();
     expect(component.queryByText("Child: 1")).toBeTruthy();
     expect(component.queryByText("Sibling: 1")).toBeTruthy();
     expect(component.queryByText("Unused: 0")).toBeTruthy();

--- a/src/spec.tsx
+++ b/src/spec.tsx
@@ -1,51 +1,92 @@
-import * as React from "react";
+import React, { useState } from "react";
 import { render, cleanup, fireEvent } from "@testing-library/react";
 
 import { KeyHandler, Provider, FocusGroup } from "./index";
+
+function TestComponent() {
+  const [clickCounts, setClickCounts] = useState<Record<string, number>>({
+    parent: 0,
+    child: 0,
+    sibling: 0,
+    unused: 0,
+  });
+  return (
+    <div>
+      <Provider>
+        <div>
+          <div>
+            <span>Parent: {clickCounts.parent}</span>
+            <span>Child: {clickCounts.child}</span>
+            <span>Sibling: {clickCounts.sibling}</span>
+            <span>Unused: {clickCounts.unused}</span>
+          </div>
+          <FocusGroup>
+            <KeyHandler
+              triggers={[{ key: "KeyA" }]}
+              handler={() =>
+                setClickCounts((prev) => ({
+                  ...prev,
+                  parent: prev.parent + 1,
+                }))
+              }
+            />
+            {clickCounts.parent > 0 && (
+              <div>
+                <span>Showing!</span>
+                <FocusGroup>
+                  <KeyHandler
+                    triggers={[{ key: "KeyA" }]}
+                    handler={() =>
+                      setClickCounts((prev) => ({
+                        ...prev,
+                        child: prev.child + 1,
+                      }))
+                    }
+                  />
+                  <KeyHandler
+                    triggers={[{ key: "KeyA" }]}
+                    handler={() =>
+                      setClickCounts((prev) => ({
+                        ...prev,
+                        sibling: prev.sibling + 1,
+                      }))
+                    }
+                  />
+                  <KeyHandler
+                    triggers={[{ key: "KeyV" }]}
+                    handler={() =>
+                      setClickCounts((prev) => ({
+                        ...prev,
+                        unused: prev.unused + 1,
+                      }))
+                    }
+                  />
+                </FocusGroup>
+              </div>
+            )}
+          </FocusGroup>
+        </div>
+      </Provider>
+    </div>
+  );
+}
 
 describe("<KeyHandler />", () => {
   afterEach(cleanup);
 
   test("matching key is triggered", () => {
-    const handlerSpy = jest.fn();
-    const anotherSpy = jest.fn();
-    const shadowedGroupSpy = jest.fn();
-    const unusedHandlerSpy = jest.fn();
-    render(
-      <div>
-        <Provider>
-          <div>
-            <FocusGroup>
-              <KeyHandler
-                triggers={[{ key: "KeyA" }]}
-                handler={shadowedGroupSpy}
-              />
-              <div>
-                <FocusGroup>
-                  <KeyHandler
-                    triggers={[{ key: "KeyA" }]}
-                    handler={handlerSpy}
-                  />
-                  <KeyHandler
-                    triggers={[{ key: "KeyA" }]}
-                    handler={anotherSpy}
-                  />
-                  <KeyHandler
-                    triggers={[{ key: "KeyV" }]}
-                    handler={unusedHandlerSpy}
-                  />
-                </FocusGroup>
-              </div>
-            </FocusGroup>
-          </div>
-        </Provider>
-      </div>
-    );
+    const component = render(<TestComponent />);
 
     fireEvent.keyDown(document.body, { code: "KeyA" });
-    expect(handlerSpy).toHaveBeenCalledTimes(1);
-    expect(anotherSpy).toHaveBeenCalledTimes(1);
-    expect(shadowedGroupSpy).toHaveBeenCalledTimes(0);
-    expect(unusedHandlerSpy).toHaveBeenCalledTimes(0);
+    expect(component.queryByText("Parent: 1")).toBeTruthy();
+    expect(component.queryByText("Child: 0")).toBeTruthy();
+    expect(component.queryByText("Sibling: 0")).toBeTruthy();
+    expect(component.queryByText("Unused: 0")).toBeTruthy();
+
+    fireEvent.keyDown(document.body, { code: "KeyA" });
+    expect(component.queryByText("Parent: 1")).toBeTruthy();
+    expect(component.queryByText("Child: 1")).toBeTruthy();
+    expect(component.queryByText("Sibling: 1")).toBeTruthy();
+    expect(component.queryByText("Unused: 0")).toBeTruthy();
   });
 });


### PR DESCRIPTION
While "bottom-up" makes sense when rendering all at once, it is often the case that we render a group _after_ another group (opening a modal, etc). We didn't test rerendering so it was hard to catch. Added a much more thorough test case to ensure that rendering in any order should still trigger the "newest" added group, even if being repushed.

The additional guards should ensure that:

1. Groups are only initialized ("pushed") once, even if a rerender is triggered.
2. Handlers are pushed _after_ groups are pushed.
3. Even if groups end up out of order due to React choosing to batch renders differently, we always pick the "highest" group.