### PR TITLE
Allow for "prerelease" version bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,9 @@ A key-handler that uses react context to create key handlers focused around a co
 
 ## Status
 
-| Branch   | URL                                              | Build Status                                                                                                                                |
-| -------- | ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| Branch | URL                                                           | Build Status                                                                                                                                                      |
+| ------ | ------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `main` | https://www.npmjs.com/package/@cala/react-focused-key-handler | [![Actions Status](https://github.com/ca-la/react-focused-key-handler/workflows/Node%20CI/badge.svg)](https://github.com/ca-la/react-focused-key-handler/actions) |
-
-
 
 ## Installation
 
@@ -52,22 +50,25 @@ return (
       // At the layer boundry for this group of key handlers
       <FocusGroup>
         // In the children of the group add keyhandlers as needed.
-        <KeyHandler
-          triggers={[{ key: 'Escape' }]}
-          handler={handlerStub}
-        />
+        <KeyHandler triggers={[{ key: "Escape" }]} handler={handlerStub} />
       </FocusGroup>
     </Provider>
   </App>
-)
+);
 ```
 
-## Contributing
+## Releasing
 
-To tag off and release a new version to npm, run the release script:
+We use a script that ensures we release from the `main` branch, and performs the correct `npm version` and `npm publish` steps. Here is an example:
 
-```
-$ ./bin/release patch    # 0.0.x - bug fixes
-$ ./bin/release minor    # 0.x.0 - new features or changes
-$ ./bin/release major    # x.0.0 - large, backwards-incompatible changes
+```shell
+# Assuming the current version is: 1.0.0
+
+# bumps major and creates a release candidate, publishing it to the `next` npm tag
+# new version: 2.0.0-rc.0
+bin/release premajor next
+
+# bumps patch, publishing it to the `latest` npm tag
+# new version: 1.0.1
+bin/release patch
 ```

--- a/bin/release
+++ b/bin/release
@@ -14,11 +14,20 @@ main() {
   release_type=${1:-other}
   prerelease_flag=${2:-""}
 
+  if [[ $release_type == 'release' ]] &&
+    [[ $prerelease_flag != '--prerelease' ]]
+  then
+    echo 'You must specify --prerelease in order to use the "release" version'
+    exit 1
+  fi
+
+
   if [[ $release_type != 'major' ]] &&
     [[ $release_type != 'minor' ]] &&
-    [[ $release_type != 'patch' ]]
+    [[ $release_type != 'patch' ]] &&
+    [[ $release_type != 'release' ]]
   then
-    echo 'Usage: release [major|minor|patch] [--prerelease]'
+    echo 'Usage: release [major|minor|patch|release] [--prerelease]'
     exit 1
   fi
 

--- a/bin/release
+++ b/bin/release
@@ -12,22 +12,11 @@ preauth_pgp_signature() {
 
 main() {
   release_type=${1:-other}
-  prerelease_flag=${2:-""}
+  tag=${2:-"latest"}
 
-  if [[ $release_type == 'release' ]] &&
-    [[ $prerelease_flag != '--prerelease' ]]
-  then
-    echo 'You must specify --prerelease in order to use the "release" version'
-    exit 1
-  fi
-
-
-  if [[ $release_type != 'major' ]] &&
-    [[ $release_type != 'minor' ]] &&
-    [[ $release_type != 'patch' ]] &&
-    [[ $release_type != 'release' ]]
-  then
-    echo 'Usage: release [major|minor|patch|release] [--prerelease]'
+  if [[ $release_type == other ]] ; then
+    echo 'Usage: bin/release [semver] [npm tag (default "latest")]'
+    echo 'See: https://docs.npmjs.com/cli/v6/commands/npm-version'
     exit 1
   fi
 
@@ -46,19 +35,13 @@ main() {
     exit 1
   fi
 
-  bin/test
   preauth_pgp_signature
 
   git pull --ff-only origin main
 
-  if [[ "$prerelease_flag" == "--prerelease" ]]; then
-    git_hash=$(git rev-parse --verify HEAD --short=8)
-    npm version pre${release_type} --preid $git_hash
-    npm publish --tag next
-  else
-    npm version $release_type
-    npm publish
-  fi
+  # Add a preid of "rc" for the varirous prerelease version
+  npm version ${release_type} --preid rc
+  npm publish --tag $tag
 
   git push --tags
   git push origin main


### PR DESCRIPTION
I wasn't an expert on `npm version`, but I guess I kinda am now 😳 

In order to bump the prerelease without changing the main part of the version number, I need to specify the version bump as `prerelease`. The last change I made in #21 just allows setting `premajor`, `preminor`, and `prepatch`.