### PR TITLE
Provide a "base" focus group

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,4 +7,4 @@ export {
 
 export { FocusGroup } from "./focus-group";
 
-export { Provider } from "./focused-stack/context";
+export { Provider } from "./provider";

--- a/src/provider.tsx
+++ b/src/provider.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { Provider as KeyHandlerProvider } from "./focused-stack/context";
+import { FocusGroup } from "./focus-group";
+
+interface OwnProps {
+  children: React.ReactNode;
+}
+
+export function Provider({ children }: OwnProps) {
+  return (
+    <KeyHandlerProvider>
+      <FocusGroup>{children}</FocusGroup>
+    </KeyHandlerProvider>
+  );
+}


### PR DESCRIPTION
Many of our tests do not provide a base `FocusGroup` for the component that is being tested. That was falling back to the global `document.body` handler that I removed in #20, so this adds a base-level focus group that is added at the same time as the main provider.