### PR TITLE
Treat textarea as an "input"

### DIFF
--- a/src/focused-stack/index.ts
+++ b/src/focused-stack/index.ts
@@ -78,7 +78,9 @@ export class FocusedStack {
     }
     const target = e.target as HTMLElement | null;
     const isContentEditable = target
-      ? target.nodeName === "INPUT" || target.isContentEditable
+      ? target.nodeName === "INPUT" ||
+        target.nodeName === "TEXTAREA" ||
+        target.isContentEditable
       : false;
 
     for (const handlerObject of handlerObjects) {

--- a/src/focused-stack/spec.ts
+++ b/src/focused-stack/spec.ts
@@ -3,7 +3,7 @@ import { Modifier } from "../key-handler";
 
 let FocusedKeyHandlerStack: FocusedStack;
 
-describe("Focused Hanlder Stack", () => {
+describe("Focused Handler Stack", () => {
   beforeEach(() => {
     FocusedKeyHandlerStack = new FocusedStack();
   });
@@ -123,6 +123,14 @@ describe("Focused Hanlder Stack", () => {
     FocusedKeyHandlerStack.fireEvent({
       code: "Escape",
       target: { nodeName: "INPUT", isContentEditable: false },
+    } as any);
+    FocusedKeyHandlerStack.fireEvent({
+      code: "Escape",
+      target: { nodeName: "TEXTAREA", isContentEditable: false },
+    } as any);
+    FocusedKeyHandlerStack.fireEvent({
+      code: "Escape",
+      target: { nodeName: "svg", isContentEditable: true },
     } as any);
 
     expect(mockHandler).not.toHaveBeenCalled();


### PR DESCRIPTION
This came up while working on a textarea in the design tool: pressing any of the keys that trigger tool changes while typing in that textarea caused the trigger to fire. I'm surprised we haven't been bit by this before, but it's possible that the only `textarea` inputs we have happen to be in groups that only listen for `Escape` or other non-text keys.