### PR TITLE
E 3 cancel melody on unregistered key entry

### DIFF
--- a/src/focused-stack/index.ts
+++ b/src/focused-stack/index.ts
@@ -85,7 +85,7 @@ export class FocusedStack {
     const handlerObjects = handlerGroup.handlers[key];
 
     if (!handlerObjects) {
-	    this.tearDown();
+      this.tearDown();
       return;
     }
     const target = e.target as HTMLElement | null;

--- a/src/focused-stack/index.ts
+++ b/src/focused-stack/index.ts
@@ -85,6 +85,7 @@ export class FocusedStack {
     const handlerObjects = handlerGroup.handlers[key];
 
     if (!handlerObjects) {
+	    this.tearDown();
       return;
     }
     const target = e.target as HTMLElement | null;

--- a/src/spec.tsx
+++ b/src/spec.tsx
@@ -165,6 +165,12 @@ describe("<KeyHandler />", () => {
     fireEvent.keyDown(document.body, { code: "KeyC" });
     fireEvent.keyDown(document.body, { code: "KeyA" });
     fireEvent.keyDown(document.body, { code: "KeyD" });
+    //Check to confirm that entering a key that is not a part of the melody in the middle of a melody does nothing
+    fireEvent.keyDown(document.body, { code: "KeyA" });
+    fireEvent.keyDown(document.body, { code: "KeyB" });
+    fireEvent.keyDown(document.body, { code: "KeyT" });
+    fireEvent.keyDown(document.body, { code: "KeyC" });
+    //Check to confirm a key combination that exceeds timeout does not work
     fireEvent.keyDown(document.body, { code: "KeyA" });
     jest.advanceTimersByTime(2001);
     fireEvent.keyDown(document.body, { code: "KeyB" });

--- a/src/spec.tsx
+++ b/src/spec.tsx
@@ -165,12 +165,12 @@ describe("<KeyHandler />", () => {
     fireEvent.keyDown(document.body, { code: "KeyC" });
     fireEvent.keyDown(document.body, { code: "KeyA" });
     fireEvent.keyDown(document.body, { code: "KeyD" });
-    //Check to confirm that entering a key that is not a part of the melody in the middle of a melody does nothing
+    // Check to confirm that entering a key that is not a part of the melody in the middle of a melody does nothing
     fireEvent.keyDown(document.body, { code: "KeyA" });
     fireEvent.keyDown(document.body, { code: "KeyB" });
     fireEvent.keyDown(document.body, { code: "KeyT" });
     fireEvent.keyDown(document.body, { code: "KeyC" });
-    //Check to confirm a key combination that exceeds timeout does not work
+    // Check to confirm a key combination that exceeds timeout does not work
     fireEvent.keyDown(document.body, { code: "KeyA" });
     jest.advanceTimersByTime(2001);
     fireEvent.keyDown(document.body, { code: "KeyB" });

--- a/src/spec.tsx
+++ b/src/spec.tsx
@@ -163,19 +163,21 @@ describe("<KeyHandler />", () => {
     fireEvent.keyDown(document.body, { code: "KeyA" });
     fireEvent.keyDown(document.body, { code: "KeyB" });
     fireEvent.keyDown(document.body, { code: "KeyC" });
+    expect(component.queryByText("level2: 1")).toBeTruthy();
     fireEvent.keyDown(document.body, { code: "KeyA" });
     fireEvent.keyDown(document.body, { code: "KeyD" });
+    expect(component.queryByText("level1: 1")).toBeTruthy();
     // Check to confirm that entering a key that is not a part of the melody in the middle of a melody does nothing
     fireEvent.keyDown(document.body, { code: "KeyA" });
     fireEvent.keyDown(document.body, { code: "KeyB" });
     fireEvent.keyDown(document.body, { code: "KeyT" });
     fireEvent.keyDown(document.body, { code: "KeyC" });
+    expect(component.queryByText("level2: 1")).toBeTruthy();
     // Check to confirm a key combination that exceeds timeout does not work
     fireEvent.keyDown(document.body, { code: "KeyA" });
     jest.advanceTimersByTime(2001);
     fireEvent.keyDown(document.body, { code: "KeyB" });
     fireEvent.keyDown(document.body, { code: "KeyC" });
-    expect(component.queryByText("level1: 1")).toBeTruthy();
     expect(component.queryByText("level2: 1")).toBeTruthy();
   });
   test("Custom Timeout functions correctly", async () => {


### PR DESCRIPTION
Changes :
- In a focus group if a non matching key event is listened to,  we call the teardown function.
-Added some code in the spec file to ensure this new change works.