### PR TITLE
Add support for `preventDefault` prop on KeyHandler

### DIFF
--- a/src/key-handler/index.tsx
+++ b/src/key-handler/index.tsx
@@ -20,7 +20,6 @@ type KeyboardEventHandler = (event: KeyboardEvent) => void;
 
 interface LeafProp {
   handler: KeyboardEventHandler;
-  stopPropagation?: boolean;
   preventDefault?: boolean;
 }
 
@@ -37,7 +36,6 @@ export function KeyHandler(props: KeyHandlerProps) {
   const [shouldRenderChildren, setShouldRenderChildren] = useState(false);
   const handler = "handler" in rest ? rest.handler : null;
   const children = "children" in rest ? rest.children : null;
-  const stopPropagation = "stopPropagation" in rest ? rest.stopPropagation : false;
   const preventDefault = "preventDefault" in rest ? rest.preventDefault : false;
 
   useLayoutEffect(
@@ -48,10 +46,6 @@ export function KeyHandler(props: KeyHandlerProps) {
         };
       }
       const wrappedHandler = (e: KeyboardEvent) => {
-        if (stopPropagation) {
-          e.stopPropagation();
-        }
-
         if (preventDefault) {
           e.preventDefault();
         }

--- a/src/key-handler/index.tsx
+++ b/src/key-handler/index.tsx
@@ -20,6 +20,8 @@ type KeyboardEventHandler = (event: KeyboardEvent) => void;
 
 interface LeafProp {
   handler: KeyboardEventHandler;
+  stopPropagation?: boolean;
+  preventDefault?: boolean;
 }
 
 interface NodeProp {
@@ -35,6 +37,8 @@ export function KeyHandler(props: KeyHandlerProps) {
   const [shouldRenderChildren, setShouldRenderChildren] = useState(false);
   const handler = "handler" in rest ? rest.handler : null;
   const children = "children" in rest ? rest.children : null;
+  const stopPropagation = "stopPropagation" in rest ? rest.stopPropagation : false;
+  const preventDefault = "preventDefault" in rest ? rest.preventDefault : false;
 
   useLayoutEffect(
     function handlerLifecycle() {
@@ -44,6 +48,14 @@ export function KeyHandler(props: KeyHandlerProps) {
         };
       }
       const wrappedHandler = (e: KeyboardEvent) => {
+        if (stopPropagation) {
+          e.stopPropagation();
+        }
+
+        if (preventDefault) {
+          e.preventDefault();
+        }
+
         if (handler) {
           handler(e);
           focusedStack.tearDown();

--- a/src/spec.tsx
+++ b/src/spec.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { render, cleanup, fireEvent } from "@testing-library/react";
+import { act, render, cleanup, fireEvent } from "@testing-library/react";
 
 import { KeyHandler, Provider, FocusGroup } from "./index";
 
@@ -180,6 +180,7 @@ describe("<KeyHandler />", () => {
     fireEvent.keyDown(document.body, { code: "KeyC" });
     expect(component.queryByText("level2: 1")).toBeTruthy();
   });
+
   test("Custom Timeout functions correctly", async () => {
     const component = render(
       <Provider timeout={3000}>
@@ -191,5 +192,64 @@ describe("<KeyHandler />", () => {
     fireEvent.keyDown(document.body, { code: "KeyB" });
     fireEvent.keyDown(document.body, { code: "KeyC" });
     expect(component.queryByText("level2: 1")).toBeTruthy();
+  });
+
+  describe("preventDefault", () => {
+    let callCount = 0;
+
+    const keyboardEvent = {
+      code: "Tab",
+    };
+
+    beforeEach(() => {
+      callCount = 0;
+    });
+
+    test("is not active by default", async () => {
+      render(
+        <Provider>
+          <FocusGroup>
+            <input type='text' className='input' />
+            <input type='text' className='input2' />
+            <KeyHandler
+              triggers={[{ key: "Tab", shouldTriggerInInputs: true }]}
+              handler={() =>
+                callCount++
+              }
+            />
+          </FocusGroup>
+        </Provider>
+      );
+
+      const input = document.querySelector(".input") as HTMLInputElement;
+      input.focus();
+      fireEvent.keyDown(input, keyboardEvent);
+      expect(callCount).toBe(1);
+      expect(input.matches(":focus")).toBe(false);
+    });
+
+    test("is active when props are specified", async () => {
+      render(
+        <Provider>
+          <FocusGroup>
+            <input type='text' className='input' />
+            <input type='text' className='input2' />
+            <KeyHandler
+              triggers={[{ key: "Tab", shouldTriggerInInputs: true }]}
+              handler={() =>
+                callCount++
+              }
+              preventDefault
+            />
+          </FocusGroup>
+        </Provider>
+      );
+
+      const input = document.querySelector(".input") as HTMLInputElement;
+      input.focus();
+      fireEvent.keyDown(input, keyboardEvent);
+      expect(callCount).toBe(1);
+      expect(input.matches(":focus")).toBe(true);
+    });
   });
 });

--- a/src/spec.tsx
+++ b/src/spec.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { act, render, cleanup, fireEvent } from "@testing-library/react";
+import { render, cleanup, fireEvent } from "@testing-library/react";
 
 import { KeyHandler, Provider, FocusGroup } from "./index";
 
@@ -180,7 +180,6 @@ describe("<KeyHandler />", () => {
     fireEvent.keyDown(document.body, { code: "KeyC" });
     expect(component.queryByText("level2: 1")).toBeTruthy();
   });
-
   test("Custom Timeout functions correctly", async () => {
     const component = render(
       <Provider timeout={3000}>
@@ -192,64 +191,5 @@ describe("<KeyHandler />", () => {
     fireEvent.keyDown(document.body, { code: "KeyB" });
     fireEvent.keyDown(document.body, { code: "KeyC" });
     expect(component.queryByText("level2: 1")).toBeTruthy();
-  });
-
-  describe("preventDefault", () => {
-    let callCount = 0;
-
-    const keyboardEvent = {
-      code: "Tab",
-    };
-
-    beforeEach(() => {
-      callCount = 0;
-    });
-
-    test("is not active by default", async () => {
-      render(
-        <Provider>
-          <FocusGroup>
-            <input type='text' className='input' />
-            <input type='text' className='input2' />
-            <KeyHandler
-              triggers={[{ key: "Tab", shouldTriggerInInputs: true }]}
-              handler={() =>
-                callCount++
-              }
-            />
-          </FocusGroup>
-        </Provider>
-      );
-
-      const input = document.querySelector(".input") as HTMLInputElement;
-      input.focus();
-      fireEvent.keyDown(input, keyboardEvent);
-      expect(callCount).toBe(1);
-      expect(input.matches(":focus")).toBe(false);
-    });
-
-    test("is active when props are specified", async () => {
-      render(
-        <Provider>
-          <FocusGroup>
-            <input type='text' className='input' />
-            <input type='text' className='input2' />
-            <KeyHandler
-              triggers={[{ key: "Tab", shouldTriggerInInputs: true }]}
-              handler={() =>
-                callCount++
-              }
-              preventDefault
-            />
-          </FocusGroup>
-        </Provider>
-      );
-
-      const input = document.querySelector(".input") as HTMLInputElement;
-      input.focus();
-      fireEvent.keyDown(input, keyboardEvent);
-      expect(callCount).toBe(1);
-      expect(input.matches(":focus")).toBe(true);
-    });
   });
 });


### PR DESCRIPTION
I spent way too long trying to test this and failed; both by providing a stub `preventDefault` method on the event itself, and simulating the expected behavior (see 2nd commit). From what I can tell, the limitations of testing-library & jsdom make both of these tactics ~impossible.